### PR TITLE
Removes post-build commands left in vcxproj file

### DIFF
--- a/AC6CameraTweaks/AC6CameraTweaks.vcxproj
+++ b/AC6CameraTweaks/AC6CameraTweaks.vcxproj
@@ -129,9 +129,6 @@
       <EnableUAC>false</EnableUAC>
       <DelayLoadDLLs>minhook.x64.dll</DelayLoadDLLs>
     </Link>
-    <PostBuildEvent>
-      <Command>copy $(TargetDir)$(TargetName)$(TargetExt) "D:\games\Armored Core VI Fires of Rubicon\Game"</Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -153,9 +150,6 @@
       <EnableUAC>false</EnableUAC>
       <DelayLoadDLLs>minhook.x64.dll</DelayLoadDLLs>
     </Link>
-    <PostBuildEvent>
-      <Command>copy $(TargetDir)$(TargetName)$(TargetExt) "D:\games\Armored Core VI Fires of Rubicon\Game"</Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="framework.h" />


### PR DESCRIPTION
Should be moved to `AC6CameraTweaks.vcxproj.user` in the same directory, e.g.

```
<?xml version="1.0" encoding="utf-8"?>
<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
  <ItemDefinitionGroup>
    <PostBuildEvent>
      <Command>copy $(TargetDir)$(TargetName)$(TargetExt) "D:\games\Armored Core VI Fires of Rubicon\Game"</Command>
    </PostBuildEvent>
  </ItemDefinitionGroup>
</Project>
```